### PR TITLE
Fix for imagemagick compare returns 1 when images are dissimiliar

### DIFF
--- a/src/Zodyac/Behat/PerceptualDiffExtension/Comparator/ScreenshotComparator.php
+++ b/src/Zodyac/Behat/PerceptualDiffExtension/Comparator/ScreenshotComparator.php
@@ -195,9 +195,9 @@ class ScreenshotComparator implements EventSubscriberInterface
         $output = array();
         exec($this->getCompareCommand($baselineFile, $screenshotFile, $tempFile), $output, $return);
 
-        if ($return === 0) {
+        if ($return === 0 || $return === 1) {
             // Check that there are some differences
-            if ($output[0] > 0) {
+            if ($return === 1) {
                 $diffFile = str_replace($screenshotPath, $diffPath, $screenshotFile);
                 $this->ensureDirectoryExists($diffFile);
 


### PR DESCRIPTION
Based on the imagemagick documentation the compare program returns 1 when images are dissimiliar.

http://www.imagemagick.org/script/compare.php

> The compare program returns 2 on error otherwise 0 if the images are similar or 1 if they are dissimilar.
